### PR TITLE
Fix compilation by adding missing QPainterPath header

### DIFF
--- a/hoerbert/triplecheckbox.h
+++ b/hoerbert/triplecheckbox.h
@@ -23,6 +23,7 @@
 #define TRIPLECHECKBOX_H
 
 #include <QWidget>
+#include <QPainterPath>
 
 /*!
  * @brief Custom checkbox widget which has three states - unchecked, checked and "3"


### PR DESCRIPTION
Compilation fails on my machine (Gentoo Linux with Qt 5.15.1) with the following error:
```
/home/kripton/git/hoerbert-software/hoerbert/triplecheckbox.cpp:79:18: error: variable has incomplete type 'QPainterPath'
    QPainterPath checkPath;
                 ^
/usr/include/qt5/QtGui/qmatrix.h:54:7: note: forward declaration of 'QPainterPath'
class QPainterPath;
      ^
1 error generated.
Error while processing /home/kripton/git/hoerbert-software/hoerbert/triplecheckbox.cpp.
```

Adding the include to `triplecheckbox.h` fixes the issue for me.

Thanks for developing this as Open Source!