### PR TITLE
Linux: Use ID_DRIVE_FLASH_SD instead of ID_USB_DRIVER to check for SD card

### DIFF
--- a/hoerbert/devicemanager.cpp
+++ b/hoerbert/devicemanager.cpp
@@ -87,7 +87,12 @@ bool DeviceManager::isRemovable(const QString &volumeRoot)
     QString cmd = "udevadm info --query=property --export --name=" + volumeRoot;
     QString output = m_processExecutor.executeCommand(cmd).second;
 
-    return output.contains(QRegExp("ID_USB_DRIVER='usb-storage'", Qt::CaseSensitive));
+    if ( output.contains(QRegExp("ID_DRIVE_FLASH_SD='1'", Qt::CaseSensitive)) ||
+         output.contains(QRegExp("ID_USB_DRIVER='usb-storage'", Qt::CaseSensitive)) )
+    {
+        return true;
+    }
+    return false;
 #endif
 }
 
@@ -106,7 +111,12 @@ bool DeviceManager::isEjectable(const QString &volumeRoot)
     QString cmd = "udevadm info --query=property --export --name=" + volumeRoot;
     QString output = m_processExecutor.executeCommand(cmd).second;
 
-    return output.contains(QRegExp("ID_USB_DRIVER='usb-storage'", Qt::CaseSensitive));
+    if ( output.contains(QRegExp("ID_DRIVE_FLASH_SD='1'", Qt::CaseSensitive)) ||
+      output.contains(QRegExp("ID_USB_DRIVER='usb-storage'", Qt::CaseSensitive)) )
+    {
+        return true;
+    }
+    return false;
 #endif
 }
 


### PR DESCRIPTION
As mentioned in #12 checking for `ID_DRIVE_FLASH_SD` helps recognizing the card

On some systems e.g. with external card readers the drive may show up as USB storage device, while with an internal card reader it might show up with the ID_DRIVE_FLASH_SD property.

I've tested this locally with a micro SD card in the internal card reader, an SD card in an external card reader and a USB flash drive which did also get recognized by the `ID_USB_DRIVER='usb-storage'` check.