### PR TITLE
Allow .opus files to be added to Hoerbert.

### DIFF
--- a/hoerbert/define.h
+++ b/hoerbert/define.h
@@ -50,7 +50,7 @@ const QString BAR_STYLE_TEMPLATE = "#CardSizeBar {background: qlineargradient(sp
 
 //qradialgradient(cx: 0.5, cy: 0.5, radius: 2, fx: 0.5, fy: 1, stop: 0 rgba(255,30,30,255), stop: 0.2 rgba(255,30,30,144), stop: 0.4 rgba(255,30,30,32)
 
-const QString SUPPORTED_FILES = "*.wav *.mp3 *.ogg *.flac *.m4a *.m4b *.wma *.aif *.aiff *cda *.m3u *.m3u8 *.wpl *.xml *.xspf";
+const QString SUPPORTED_FILES = "*.wav *.mp3 *.ogg *.opus *.flac *.m4a *.m4b *.wma *.aif *.aiff *cda *.m3u *.m3u8 *.wpl *.xml *.xspf";
 
 const QColor CL_DIR0 = QColor(60, 40, 43);
 const QColor CL_DIR1 = QColor(169, 21, 11);


### PR DESCRIPTION
Ffmpeg can transcode opus files. File extension is usually .opus, see [wikipedia](https://en.wikipedia.org/wiki/Opus_(audio_format))